### PR TITLE
Replace the resinator dependency with upstreamed version.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,10 +15,6 @@ pub fn build(b: *std.build.Builder) void {
         .optimize = optimize,
     });
 
-    const resinator_dep = b.dependency("resinator", .{
-        .optimize = .ReleaseFast,
-    });
-
     const exe = b.addExecutable(.{
         .name = "open3DMM",
         .target = target,
@@ -33,22 +29,18 @@ pub fn build(b: *std.build.Builder) void {
     exe.addIncludePath(.{ .path = "src/studio" });
     exe.addCSourceFiles(open3dmm_sources, open3dmm_flags);
 
-    const resinator_exe = resinator_dep.artifact("resinator");
-
-    const resinator_run = b.addRunArtifact(resinator_exe);
-
-    resinator_run.addArgs(&.{
-        "/y",
-        "/i",
-        b.pathFromRoot("inc"),
-        "/i",
-        b.getInstallPath(.header, ""),
-        "/i",
-        b.pathFromRoot("src"),
+    exe.addWin32ResourceFile(.{
+        .file = .{ .path = "src/studio/utest.rc" },
+        .flags = &.{
+            "/y",
+            "/i",
+            b.pathFromRoot("inc"),
+            "/i",
+            b.getInstallPath(.header, ""),
+            "/i",
+            b.pathFromRoot("src"),
+        },
     });
-
-    resinator_run.addFileArg(.{ .path = "src/studio/utest.rc" });
-    exe.addObjectFile(resinator_run.addOutputFileArg("utest.res"));
 
     b.installArtifact(exe);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,9 +6,5 @@
             .url = "https://github.com/jayrod246/open3DMM-core/archive/refs/heads/main.tar.gz",
             .hash = "12206d54ddd221994eb541141062c75c77833e0acb1a3bea7bb9727f2b4cdc9232e6",
         },
-        .resinator = .{
-            .url = "https://github.com/squeek502/resinator/archive/41e67244161337925554f5150fcdea2e816305b3.tar.gz",
-            .hash = "122090609f5c4d0e1602b7907db170fcc0b3c32e22b08c46f264f12bf74be3dbba1b",
-        },
     },
 }


### PR DESCRIPTION
Now that resinator is merged with Zig, we don't need to fetch it as a dependency.