### PR TITLE
Fix Resinator includes after recent Zig build api changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /zig-cache
 /zig-out
-/generated

--- a/build.zig
+++ b/build.zig
@@ -31,14 +31,13 @@ pub fn build(b: *std.Build) void {
 
     exe.addWin32ResourceFile(.{
         .file = b.path("src/studio/utest.rc"),
+        .include_paths = &.{exe.getEmittedIncludeTree()},
         .flags = &.{
             "/y",
             "/i",
-            b.pathFromRoot("inc"),
+            "inc",
             "/i",
-            b.getInstallPath(.header, ""),
-            "/i",
-            b.pathFromRoot("src"),
+            "src",
         },
     });
 

--- a/build.zig
+++ b/build.zig
@@ -29,28 +29,16 @@ pub fn build(b: *std.Build) void {
     exe.addIncludePath(b.path("src/studio"));
     exe.addCSourceFiles(.{ .files = open3dmm_sources, .flags = open3dmm_flags });
 
-    const kauai_dep = @"open3dmm-core_dep".builder.dependency("kauai", .{
-        .target = target,
-        .optimize = optimize,
-    });
-
-    const copy_files = b.addWriteFiles();
-    copy_files.addCopyFileToSource(@"open3dmm-core_dep".path("inc/socdef.h"), "generated/core/socdef.h");
-    copy_files.addCopyFileToSource(kauai_dep.path("kauai/src/frameres.h"), "generated/frameres.h");
-    copy_files.addCopyFileToSource(kauai_dep.path("kauai/src/framedef.h"), "generated/framedef.h");
-    copy_files.addCopyFileToSource(kauai_dep.path("kauai/src/frame.rc"), "generated/frame.rc");
-    exe.step.dependOn(&copy_files.step);
-    
     exe.addWin32ResourceFile(.{
         .file = b.path("src/studio/utest.rc"),
         .flags = &.{
             "/y",
             "/i",
-            "inc",
+            b.pathFromRoot("inc"),
             "/i",
-            "generated",
+            b.getInstallPath(.header, ""),
             "/i",
-            "src",
+            b.pathFromRoot("src"),
         },
     });
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.0.0",
     .dependencies = .{
         .@"open3dmm-core" = .{
-            .url = "https://github.com/jayrod246/open3DMM-core/archive/c03c9c7476c80b0e61b102cdc17f103a5052cd33.tar.gz",
-            .hash = "1220e890a6306c00a3c36694f870318ce8e4cdcfd81d8db3d5f3b312b25d570dd021",
+            .url = "https://github.com/jayrod246/open3DMM-core/archive/1d1b90bd3f592f3641d53486ad5085e750668f94.tar.gz",
+            .hash = "12208261a8eb295f3bf2f9e9420bcfeca8bd4c773a1bdc4d784858efa74ee192aebe",
         },
     },
     .paths = .{


### PR DESCRIPTION
Blocked by: https://github.com/ziglang/zig/issues/19605

Preprocessing for "src/studio/utest.rc" expects "core/socdef.h", which is installed by our open3dmm-core dependency/artifact. At the moment, resinator does not inherit the "directory that holds all of the installed headers" in it's search path. If that changes, some of these includes I was manually passing may become unnecessary:
https://github.com/jayrod246/open3DMM/blob/e719be595125f7fd0c2a95d013ac4ba046c6e553/build.zig#L34-L42